### PR TITLE
Trying to fix git hub actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        components: rustfmt, clippy
     - name: Build
       run: cargo build --verbose
     - name: Run tests


### PR DESCRIPTION
Builds are marked as failing because the rust edition is considered unstable so I need to use the nightly toolchain